### PR TITLE
Add excel download responses

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -1,0 +1,34 @@
+from io import BytesIO
+
+from django.http import HttpResponse
+
+import polars as pl
+from xlsxwriter import Workbook
+
+
+class ExcelDownloadResponse:
+    """Returns an HttpResponse with an excel file attachment created from a
+    polars dataframe.
+    """
+
+    def __new__(cls, dataframe: pl.DataFrame, file_name: str) -> HttpResponse:
+        cls.dataframe = dataframe
+        cls.file_name = file_name
+        return cls._get_response(cls)
+
+    def _get_buffer(self) -> BytesIO:
+        buffer = BytesIO()
+        with Workbook(buffer) as wb:
+            self.dataframe.write_excel(wb, autofit=True)
+        buffer.seek(0)
+        return buffer
+
+    def _get_response(self) -> HttpResponse:
+        response = HttpResponse(
+            self._get_buffer(self).read(),
+            content_type=(
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ),
+        )
+        response["Content-Disposition"] = f"attachment; filename={self.file_name}.xlsx"
+        return response

--- a/requirements.in
+++ b/requirements.in
@@ -2,3 +2,5 @@ crispy-bootstrap5
 django
 Pillow
 pip-tools
+polars
+xlsxwriter

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,8 @@ pillow==11.3.0
     # via -r requirements.in
 pip-tools==7.5.0
     # via -r requirements.in
+polars==1.33.1
+    # via -r requirements.in
 pyproject-hooks==1.2.0
     # via
     #   build
@@ -33,6 +35,8 @@ sqlparse==0.5.3
     # via django
 wheel==0.45.1
     # via pip-tools
+xlsxwriter==3.2.9
+    # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
Here's an `ExcelDownloadReponse` class that takes in a `polars.DataFrame` and handles the `HttpResponse` configuration to attach an excel file generated by the data frame.

New packages to install are `polars` and `xlsxwriter`.

Example of usage:
```python
import polars as pl

from core.utils import ExcelDownloadReponse
from order.models import Product


def view(request):
    data = Product.objects.values()
    df = pl.DataFrame(list(data))
    return ExcelDownloadReponse(df, "File Name")
```